### PR TITLE
chore: remove ESLint magic comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint sort-keys: "error" */
 module.exports = {
   extends: ["stylelint-config-standard", "stylelint-a11y/recommended"],
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,16 @@
   "eslintConfig": {
     "extends": [
       "ybiquitous/node"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "index.js"
+        ],
+        "rules": {
+          "sort-keys": "error"
+        }
+      }
     ]
   },
   "commitlint": {


### PR DESCRIPTION
Moved to `eslintConfig.overrides` in `package.json`.