### PR TITLE
feat!: drop support for Node.js 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["16", "18", "20"]
+        node-version: ["18", "20"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "ybiq": "^17.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
         "stylelint": ">=13.12.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=18.0.0"
   },
   "peerDependencies": {
     "stylelint": ">=13.12.0",


### PR DESCRIPTION
v16 reached EOF. See https://github.com/nodejs/Release#release-schedule
